### PR TITLE
Make Sentry DSN configurable by file

### DIFF
--- a/lib/puppet/reports/sentry.rb
+++ b/lib/puppet/reports/sentry.rb
@@ -6,41 +6,41 @@ rescue LoadError => e
   Puppet.err "Install the sentry-raven gem on the Puppetmaster to send reports to Sentry"
 end
 
-Puppet::Reports.register_report(:sentry) do
-  desc 'Puppet reporter to send failed runs to Sentry'
+sentry_dsn = nil
 
-  sentry_dsn = nil
-
-  if Puppet.settings[:confdir].is_a?(String)
-    sentry_conffile = File.join(Puppet.settings[:confdir], 'sentry.conf')
-    if Puppet::FileSystem.exist?(sentry_conffile)
-      File.readlines(sentry_conffile).each do |conf_line|
-        conf_line.chomp!
-        key, value = conf_line.split(/\s*=\s*/)
-        case key
-        when 'dsn'
-          sentry_dsn = URI.parse(value)
-        end
+if Puppet.settings[:confdir].is_a?(String)
+  sentry_conffile = File.join(Puppet.settings[:confdir], 'sentry.conf')
+  if Puppet::FileSystem.exist?(sentry_conffile)
+    File.readlines(sentry_conffile).each do |conf_line|
+      conf_line.chomp!
+      key, value = conf_line.split(/\s*=\s*/)
+      case key
+      when 'dsn'
+        sentry_dsn = URI.parse(value)
       end
     end
   end
+end
 
-  if ENV['PUPPET_SENTRY_DSN']
-    sentry_dsn = URI.parse(ENV['PUPPET_SENTRY_DSN'])
+if ENV['PUPPET_SENTRY_DSN']
+  sentry_dsn = URI.parse(ENV['PUPPET_SENTRY_DSN'])
+end
+
+if sentry_dsn.nil?
+  Puppet.err "Not registering Sentry report processor as DSN is not available"
+else
+  sentry_dsn_redacted = sentry_dsn.clone
+  sentry_dsn_redacted.user = '***'
+  sentry_dsn_redacted.password = '***'
+
+  Puppet.info("Registering Sentry report processor; DSN is #{sentry_dsn_redacted.to_s}")
+
+  Raven.configure do |config|
+    config.dsn = sentry_dsn.to_s
   end
 
-  if sentry_dsn.nil?
-    Puppet.err "Not registering Sentry report processor as DSN is not available"
-  else
-    sentry_dsn_redacted = sentry_dsn.clone
-    sentry_dsn_redacted.user = '***'
-    sentry_dsn_redacted.password = '***'
-
-    Puppet.info("Registering Sentry report processor; DSN is #{sentry_dsn_redacted.to_s}")
-
-    Raven.configure do |config|
-      config.dsn = sentry_dsn.to_s
-    end
+  Puppet::Reports.register_report(:sentry) do
+    desc 'Puppet reporter to send failed runs to Sentry'
 
     def process
       return unless self.status == 'failed'

--- a/lib/puppet/reports/sentry.rb
+++ b/lib/puppet/reports/sentry.rb
@@ -9,31 +9,54 @@ end
 Puppet::Reports.register_report(:sentry) do
   desc 'Puppet reporter to send failed runs to Sentry'
 
-  def process
-    return unless self.status == 'failed'
+  sentry_dsn = nil
 
-    sentry_dsn = ENV['PUPPET_SENTRY_DSN']
-
-    if not sentry_dsn
-      raise(Puppet::ParseError, 'Sentry DSN not available')
+  if Puppet.settings[:confdir].is_a?(String)
+    sentry_conffile = File.join(Puppet.settings[:confdir], 'sentry.conf')
+    if Puppet::FileSystem.exist?(sentry_conffile)
+      File.readlines(sentry_conffile).each do |conf_line|
+        conf_line.chomp!
+        key, value = conf_line.split(/\s*=\s*/)
+        case key
+        when 'dsn'
+          sentry_dsn = URI.parse(value)
+        end
+      end
     end
+  end
+
+  if ENV['PUPPET_SENTRY_DSN']
+    sentry_dsn = URI.parse(ENV['PUPPET_SENTRY_DSN'])
+  end
+
+  if sentry_dsn.nil?
+    Puppet.err "Not registering Sentry report processor as DSN is not available"
+  else
+    sentry_dsn_redacted = sentry_dsn.clone
+    sentry_dsn_redacted.user = '***'
+    sentry_dsn_redacted.password = '***'
+
+    Puppet.info("Registering Sentry report processor; DSN is #{sentry_dsn_redacted.to_s}")
 
     Raven.configure do |config|
-      config.dsn = sentry_dsn
+      config.dsn = sentry_dsn.to_s
     end
 
-    unwanted_log_levels = [:debug, :info, :notice]
-    self.logs.reject! { |log_line| unwanted_log_levels.include? log_line.level }
+    def process
+      return unless self.status == 'failed'
 
-    message = "Puppet run failed on #{self.host}\n" + self.logs.map { |log| log.message }.join("\n\n")
+      unwanted_log_levels = [:debug, :info, :notice]
+      self.logs.reject! { |log_line| unwanted_log_levels.include? log_line.level }
 
-    Raven.capture_message(message, {
-      :server_name => self.host,
-      :tags => {
-        'kind' => self.kind,
-        'version' => self.puppet_version,
-      },
-    })
+      message = "Puppet run failed on #{self.host}\n" + self.logs.map { |log| log.message }.join("\n\n")
 
+      Raven.capture_message(message, {
+        :server_name => self.host,
+        :tags => {
+          'kind' => self.kind,
+          'version' => self.puppet_version,
+        },
+      })
+    end
   end
 end


### PR DESCRIPTION
PuppetServer (or at least, earlier versions of it) scrub the environment variables before launching the Puppet Master under JRuby. This means that `PUPPET_SENTRY_DSN` doesn't make it through to the Puppet runtime. Later versions of Puppet Server let you get around this by specifying the environment in one of the config files, but as we're on a legacy version, we need another workaround.

This code looks for `sentry.conf` in the Puppet confdir (usually `/etc/puppet`) and parses out `key=value` pairs. At the moment only the key "dsn" is processed.